### PR TITLE
WIP: Perform seamless upgrade of card attributes.

### DIFF
--- a/duolingo_sync/duolingo_dialog.py
+++ b/duolingo_sync/duolingo_dialog.py
@@ -11,8 +11,11 @@ def duolingo_dialog(mw):
     your <strong>active</strong> Duolingo language. As you learn more words in Duolingo, use
     this tool again to pull those words into Anki.</p>
     
-    <p>See the <a href="https://github.com/JASchilz/AnkiSyncDuolingo/">project page</a>
-    for more information.</p>
+    <p>The cards and notes created by this plugin are customizable, and some languages may
+    include <u>pronunciation</u> or <u>gender</u> that you can add to your cards. See the
+    <a href="https://github.com/JASchilz/AnkiSyncDuolingo/">project page</a> for more information.</p>
+    
+    <hr>
 
     <p>Please enter your <strong>Duolingo</strong> username and password.</p>
     """)

--- a/duolingo_sync/duolingo_model.py
+++ b/duolingo_sync/duolingo_model.py
@@ -1,17 +1,20 @@
-from aqt.utils import askUser
+from aqt.utils import askUser, showInfo
+
+_field_names = ["Gid", "Gender", "Source", "Target", "Target Language", "Pronunciation"]
+_model_name = "Duolingo Sync"
 
 
 def create_model(mw):
     mm = mw.col.models
-    m = mm.new(_("Duolingo Sync"))
+    m = mm.new(_(_model_name))
 
-    for fieldName in ["Gid", "Gender", "Source", "Target", "Target Language", "Pronunciation"]:
-        fm = mm.newField(_(fieldName))
+    for field_name in _field_names:
+        fm = mm.newField(_(field_name))
         mm.addField(m, fm)  
 
     t = mm.newTemplate("Card 1")
     t['qfmt'] = "{{Source}}<br>\n<br>\nTo {{Target Language}}:\n\n<hr id=answer>"
-    t['afmt'] = "{{FrontSide}}\n\n<br><br>{{Target}} ({{Pronunciation}})"
+    t['afmt'] = "{{FrontSide}}\n\n<br><br>{{Target}}"
     mm.addTemplate(m, t)
 
     t = mm.newTemplate("Card 2")
@@ -23,13 +26,26 @@ def create_model(mw):
     mw.col.models.save(m)
     return m
 
+
 def get_duolingo_model(mw):
-    m = mw.col.models.byName("Duolingo Sync")
+    m = mw.col.models.byName(_model_name)
     if not m:
-        if askUser("Duolingo Sync note type not found. Create?"):
-            m = create_model(mw)
+        showInfo("Duolingo Sync note type not found. Creating.")
+        m = create_model(mw)
+
+    # Add new fields if they don't exist yet
+    fields_to_add = [field_name for field_name in _field_names if field_name not in mw.col.models.fieldNames(m)]
+    if fields_to_add:
+        showInfo("""
+        <p>The Duolingo Sync plugin has recently been upgraded to include the following attributes: {}</p>
+        <p>This change will require a full-sync of your card database to your Anki-Web account.</p>
+        """.format(", ".join(fields_to_add)))
+        for field_name in fields_to_add:
+            pass
+            fm = mw.col.models.newField(_(field_name))
+            mw.col.models.addField(m, fm)
+            mw.col.models.save(m)
+
     return m
 
-def get_duolingo_model_with_pronunciation(mw):
-    m = create_model(mw)
-    return m
+

--- a/duolingo_sync/plugin.py
+++ b/duolingo_sync/plugin.py
@@ -10,15 +10,12 @@ from anki.utils import splitFields, ids2str
 
 from .duolingo_dialog import duolingo_dialog
 from .duolingo import Duolingo, LoginFailedException
-from .duolingo_model import get_duolingo_model, get_duolingo_model_with_pronunciation
+from .duolingo_model import get_duolingo_model
 from .duolingo_thread import DuolingoThread
 
 
 def sync_duolingo():
-    if askUser("Add pronunciation?"):
-        model = get_duolingo_model_with_pronunciation(mw)
-    else:
-        model = get_duolingo_model(mw)
+    model = get_duolingo_model(mw)
 
     if not model:
         showWarning("Could not find or create Duolingo Sync note type.")
@@ -107,7 +104,7 @@ def sync_duolingo():
                     n['Gender'] = vocab['gender'] if vocab['gender'] else ''
                     n['Source'] = '; '.join(translations[vocab['word_string']])
                     n['Target'] = vocab['word_string']
-                    n['Pronunciation'] = vocab['normalized_string']
+                    n['Pronunciation'] = vocab['normalized_string'].strip()
                     n['Target Language'] = language_string
                     n.addTag(language_string)
                     n.addTag('duolingo_sync')


### PR DESCRIPTION
Addresses #21 .  Rather than creating or supporting multiple card/model types if a user upgrades from one version of _Pull from Duolingo_ to a next version, with this pull request the plugin will identify any card/model attributes not currently present, and add them to the existing "Duolingo Sync" card/model.

@Jacky2Wong I'm thinking that pronunciation is a great option that some users will want for some languages. Noun gender is another. And so instead of adding yes/no options for all helpful fields, I'm adding a note to the main dialog that looks like this:

![image](https://user-images.githubusercontent.com/6137968/72698409-f41c0980-3af8-11ea-996a-41b360b43481.png)

And in the README I'll include some brief documentation about how to add `{{Pronunciation}}` and `{{Gender}}` attributes to cards.

Todo:
  * Just a bit more testing of the plugin
  * README documentation for how to add attributes to cards.