### PR TITLE
Allow users to retrieve cards, without translations.

### DIFF
--- a/duolingo_sync/duolingo_display_login_dialog.py
+++ b/duolingo_sync/duolingo_display_login_dialog.py
@@ -22,6 +22,10 @@ def duolingo_display_login_dialog(mw):
     language specific</a> issues. You can also see a list of <a href="https://github.com/JASchilz/AnkiSyncDuolingo/labels/feature-request">feature requests</a>.
     You're invited to comment or add new issues.</p>
     
+    <p><strong>Due to recent changes in the Duolingo service, this plugin is unable to provide translations for your vocabulary.</strong>
+    You can edit in the translations on your first review. See <a href="https://github.com/JASchilz/AnkiSyncDuolingo/issues/61">this support issue</a>
+    for more information.</p>
+    
     <hr>
 
     <p>Please enter your <strong>Duolingo</strong> username and password.</p>

--- a/duolingo_sync/duolingo_model.py
+++ b/duolingo_sync/duolingo_model.py
@@ -27,19 +27,26 @@ def create_model(mw):
     return m
 
 
-def get_duolingo_model(mw):
+def get_duolingo_model(aqt):
+    mw = aqt.mw
     m = mw.col.models.byName(_model_name)
     if not m:
-        showInfo("Duolingo Sync note type not found. Creating.")
+        aqt.mw.taskman.run_on_main(
+            lambda: aqt.mw.progress.update(
+                label="Duolingo Sync note type not found. Creating..."
+            )
+        )
         m = create_model(mw)
 
     # Add new fields if they don't exist yet
     fields_to_add = [field_name for field_name in _field_names if field_name not in mw.col.models.fieldNames(m)]
     if fields_to_add:
-        showInfo("""
-        <p>The Duolingo Sync plugin has recently been upgraded to include the following attributes: {}</p>
-        <p>This change will require a full-sync of your card database to your Anki-Web account.</p>
-        """.format(", ".join(fields_to_add)))
+        aqt.mw.taskman.run_on_main(
+            lambda: showInfo("""
+                <p>The Duolingo Sync plugin has recently been upgraded to include the following attributes: {}</p>
+                <p>This change will require a full-sync of your card database to your Anki-Web account.</p>
+                """.format(", ".join(fields_to_add)))
+            )
         for field_name in fields_to_add:
             pass
             fm = mw.col.models.newField(_(field_name))

--- a/duolingo_sync/plugin.py
+++ b/duolingo_sync/plugin.py
@@ -36,7 +36,7 @@ class AddVocabResult:
 def login_and_retrieve_vocab(username, password) -> VocabRetrieveResult:
     result = VocabRetrieveResult(success=False, words_to_add=[])
 
-    model = get_duolingo_model(mw)
+    model = get_duolingo_model(aqt)
 
     note_ids = mw.col.findNotes('tag:duolingo_sync')
     notes = mw.col.db.list("select flds from notes where id in {}".format(ids2str(note_ids)))
@@ -124,20 +124,10 @@ def add_vocab(retrieve_result: VocabRetrieveResult) -> AddVocabResult:
 
     words_processed = 0
     for word_chunk in word_chunks:
-        lexeme_ids = {vocab['word_string']: vocab['id'] for vocab in word_chunk}
-        translations = lingo.get_translations([vocab['word_string'] for vocab in word_chunk])
-
-        # The `get_translations` endpoint might not always return a translation. In this case, try
-        # a couple of fallback methods
-        for word_string, translation in translations.items():
-            if not translation:
-                fallback_translation = "Translation not found for '{}'. Edit this card to add it.".format(word_string)
-                try:
-                    new_translation = lingo.get_word_definition_by_id(lexeme_ids[word_string])['translations']
-                except Exception:
-                    new_translation = fallback_translation
-
-                translations[word_string] = [new_translation if new_translation else fallback_translation]
+        translations = {
+            vocab['word_string']: ["Provide the translation for '{}' from {}.".format(vocab['word_string'], retrieve_result.language_string)]
+            for vocab in word_chunk
+        }
 
         for vocab in word_chunk:
             n = mw.col.newNote()


### PR DESCRIPTION
Duolingo has shut down the APIs that provide translations. See #59.

This allows users to retrieve their cards without error, even though those translations aren't available.

Closes #59 .