### PR TITLE
Always adds to the default deck, even if it is renamed

### DIFF
--- a/duolingo_sync/plugin.py
+++ b/duolingo_sync/plugin.py
@@ -4,6 +4,7 @@ from typing import Optional, List
 
 import requests.exceptions
 from anki.utils import splitFields, ids2str
+from anki.decks import DEFAULT_DECK_ID
 
 import aqt
 from aqt import mw
@@ -83,7 +84,7 @@ def login_and_retrieve_vocab(username, password) -> VocabRetrieveResult:
     language_string = vocabulary_response['language_string']
     vocabs = vocabulary_response['vocab_overview']
 
-    did = mw.col.decks.id("Default")
+    did = mw.col.decks.get(DEFAULT_DECK_ID)['id']
     mw.col.decks.select(did)
 
     deck = mw.col.decks.get(did)


### PR DESCRIPTION
A potential resolution to https://github.com/JASchilz/AnkiSyncDuolingo/issues/56. Grabs the default deck by ID instead of by name. This way, it can add to the default deck even if the user renames it.

I was inspired to open this PR because I renamed by default deck to "zDefault" so it would show at the bottom of my list. Before this change, the "Default" deck would be created by AnkiSyncDuolingo, but it would add the cards to the "zDefault" deck.

This PR is one attempt at solving the problem, but I can imagine its behavior may still be confusing. For example in https://github.com/JASchilz/AnkiSyncDuolingo/issues/56 the user renamed the deck to something else, and their cards were getting added to that deck instead of "Default". This PR would just make the cards sync to the renamed default deck without creating an empty "Default" deck, which is especially confusing if the user doesn't remember they renamed the default deck.

Some alternative solutions which may be better than this PR:
  - Adding the cards to a newly created "Default" deck
    - May not work well if users rename the default deck
    - At least this would be consistent with the add on description / readme
  - Adding a setting for where cards should go by default
    - More engineering work
    - Can cover the weird cases where people rename the default deck
    - Essentially requested in https://github.com/JASchilz/AnkiSyncDuolingo/issues/48
    - Considering Anki plugins have a built in JSON config editor, this may be possible to implement with no UI work